### PR TITLE
API Extension; Get the Current and Next Block Type and Object

### DIFF
--- a/Assignments/assignment4/src/te_gamestate.py
+++ b/Assignments/assignment4/src/te_gamestate.py
@@ -21,6 +21,26 @@ class GameState():
         '''
         return self.__model.falling_block_angle
 
+    def get_falling_block_type(self):
+        '''get_falling_block_type() returns a str denoting the current
+        falling block type I, J, L, O, S, T, Z
+        '''
+        return self.__model.falling_block_type
+
+    def get_falling_block_raw(self):
+        ''' returns the falling block object'''
+        return self.__model.falling_block
+
+    def get_next_block_raw(self):
+        ''' returns the next block object '''
+        return self.__model.next_block
+
+    def get_next_block_type(self):
+        '''get_falling_block_type() returns a str denoting the next
+        falling block type I, J, L, O, S, T, Z
+        '''
+        return self.__model.next_block_type
+
     def get_tiles(self):
         '''get_tiles() returns a copy of the tiles that have settled in the
             arena.  The falling block is not included in these

--- a/Assignments/assignment4/src/te_model.py
+++ b/Assignments/assignment4/src/te_model.py
@@ -115,7 +115,7 @@ class Block():
         self.__x = x
         self.__y = y
         self.__angle = 0
-        self.__type = block_type
+        self.type = block_type
         self.__falling = falling
         if block_type == 'I':
             self.__bitmap = IBlock()
@@ -326,6 +326,22 @@ class Model():
     @property
     def falling_block_angle(self):
         return self.__falling_block.angle
+
+    @property
+    def falling_block(self):
+        return self.__falling_block
+
+    @property
+    def falling_block_type(self):
+        return self.__falling_block.type
+
+    @property
+    def next_block(self):
+        return self.__next_block
+
+    @property
+    def next_block_type(self):
+        return self.__next_block.type
 
     def get_copy_of_tiles(self):
         return self.__blockfield.get_copy_of_tiles()


### PR DESCRIPTION
Added the ability to get the type of the current and next block to the gamestate API (information accessible to the player); along with the ability to get the object of the current and next block (useful for bitmap data so that the clone method does not need to be used).  This also changes the self.__type within the model to not be private so it may be accessed (self.type instead).  The object for the current and next block should not be editable.

Thank you